### PR TITLE
Add /opt/hostedtoolcache directory for GitHub Actions

### DIFF
--- a/testflows/github/hetzner/runners/scripts/startup-arm64.sh
+++ b/testflows/github/hetzner/runners/scripts/startup-arm64.sh
@@ -1,4 +1,9 @@
 set -x
+
+# Create hostedtoolcache directory for GitHub Actions (required by setup-ruby, setup-python, etc.)
+sudo mkdir -p /opt/hostedtoolcache
+sudo chown ubuntu:ubuntu /opt/hostedtoolcache
+
 echo "Install runner"
 cd /home/ubuntu
 

--- a/testflows/github/hetzner/runners/scripts/startup-x64.sh
+++ b/testflows/github/hetzner/runners/scripts/startup-x64.sh
@@ -1,4 +1,9 @@
 set -x
+
+# Create hostedtoolcache directory for GitHub Actions (required by setup-ruby, setup-python, etc.)
+sudo mkdir -p /opt/hostedtoolcache
+sudo chown ubuntu:ubuntu /opt/hostedtoolcache
+
 echo "Install runner"
 cd /home/ubuntu
 


### PR DESCRIPTION
Fixes #92

## Summary
- Create `/opt/hostedtoolcache` directory with proper ownership in runner startup scripts
- Required by actions like `ruby/setup-ruby` and `actions/setup-python`

## Problem
Actions that install language runtimes require a writable `/opt/hostedtoolcache` directory. Without it, they fail with:
```
Error: EACCES: permission denied, mkdir '/opt/hostedtoolcache'
```

## Solution
Add directory creation to both `startup-x64.sh` and `startup-arm64.sh` before the runner starts.

## Test plan
- [ ] Run a workflow using `ruby/setup-ruby` or `actions/setup-python`
- [ ] Verify no permission errors occur