### PR TITLE
Upgrade GitHub Actions Runner from 2.306.0 to 2.330.0

### DIFF
--- a/testflows/github/hetzner/runners/scripts/startup-arm64.sh
+++ b/testflows/github/hetzner/runners/scripts/startup-arm64.sh
@@ -9,43 +9,43 @@ ACTIONS_RUNNER_SHA256="9cb43527912086c7c8fb4119cb06409fcbcbd6f93a2d8507f30b07c49
 
 ACTIONS_RUNNER_ARCH="arm64"
 ACTIONS_RUNNER_FILE="actions-runner-linux-${ACTIONS_RUNNER_ARCH}-${ACTIONS_RUNNER_VERSION}.tar.gz"
-ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/$ACTIONS_RUNNER_FILE"
+ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/${ACTIONS_RUNNER_FILE}"
 CACHE_DIR="${CACHE_DIR:-/mnt/cache}"
-CACHE_DIR_GITHUB="$CACHE_DIR/github"
+CACHE_DIR_GITHUB="${CACHE_DIR}/github"
 
 download_and_verify() {
     echo "Downloading actions runner package from GitHub..."
-    curl -o "$ACTIONS_RUNNER_FILE" -L "$ACTIONS_RUNNER_URL"
-    echo "$ACTIONS_RUNNER_SHA256  $ACTIONS_RUNNER_FILE" | shasum -a 256 -c
+    curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
+    echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
 }
 
 # Try to use cache volume if available
-if [ -d "$CACHE_DIR" ]; then
-    if [ -f "$CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" ]; then
+if [ -d "${CACHE_DIR}" ]; then
+    if [ -f "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" ]; then
         echo "Found runner package in cache, verifying checksum..."
-        if echo "$ACTIONS_RUNNER_SHA256  $CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" | shasum -a 256 -c; then
+        if echo "${ACTIONS_RUNNER_SHA256}  ${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c; then
             echo "Checksum verified, copying from cache..."
-            cp "$CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" .
+            cp "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" .
         else
             echo "Cache file checksum mismatch"
             download_and_verify
             # Save to cache for future use
-            mkdir -p "$CACHE_DIR_GITHUB"
-            cp "$ACTIONS_RUNNER_FILE" "$CACHE_DIR_GITHUB/"
+            mkdir -p "${CACHE_DIR_GITHUB}"
+            cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
         fi
     else
         echo "Runner package not found in cache"
         download_and_verify
         # Save to cache for future use
-        mkdir -p "$CACHE_DIR_GITHUB"
-        cp "$ACTIONS_RUNNER_FILE" "$CACHE_DIR_GITHUB/"
+        mkdir -p "${CACHE_DIR_GITHUB}"
+        cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
     fi
 else
     echo "Cache directory not available, downloading directly..."
     download_and_verify
 fi
 
-tar xzf "./$ACTIONS_RUNNER_FILE"
+tar xzf "./${ACTIONS_RUNNER_FILE}"
 
 echo "Configure runner"
 ./config.sh --unattended --replace --url https://github.com/${GITHUB_REPOSITORY} --token ${GITHUB_RUNNER_TOKEN} --name "$(hostname)-${SERVER_TYPE_NAME}-${SERVER_LOCATION_NAME}" --runnergroup "${GITHUB_RUNNER_GROUP}" --labels "${GITHUB_RUNNER_LABELS}" --work _work --ephemeral

--- a/testflows/github/hetzner/runners/scripts/startup-x64.sh
+++ b/testflows/github/hetzner/runners/scripts/startup-x64.sh
@@ -9,43 +9,43 @@ ACTIONS_RUNNER_SHA256="af5c33fa94f3cc33b8e97937939136a6b04197e6dadfcfb3b6e33ae1b
 
 ACTIONS_RUNNER_ARCH="x64"
 ACTIONS_RUNNER_FILE="actions-runner-linux-${ACTIONS_RUNNER_ARCH}-${ACTIONS_RUNNER_VERSION}.tar.gz"
-ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/$ACTIONS_RUNNER_FILE"
+ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/${ACTIONS_RUNNER_FILE}"
 CACHE_DIR="${CACHE_DIR:-/mnt/cache}"
-CACHE_DIR_GITHUB="$CACHE_DIR/github"
+CACHE_DIR_GITHUB="${CACHE_DIR}/github"
 
 download_and_verify() {
     echo "Downloading actionsrunner package from GitHub..."
-    curl -o "$ACTIONS_RUNNER_FILE" -L "$ACTIONS_RUNNER_URL"
-    echo "$ACTIONS_RUNNER_SHA256  $ACTIONS_RUNNER_FILE" | shasum -a 256 -c
+    curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
+    echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
 }
 
 # Try to use cache volume if available
-if [ -d "$CACHE_DIR" ]; then
-    if [ -f "$CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" ]; then
+if [ -d "${CACHE_DIR}" ]; then
+    if [ -f "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" ]; then
         echo "Found runner package in cache, verifying checksum..."
-        if echo "$ACTIONS_RUNNER_SHA256  $CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" | shasum -a 256 -c; then
+        if echo "${ACTIONS_RUNNER_SHA256}  ${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c; then
             echo "Checksum verified, copying from cache..."
-            cp "$CACHE_DIR_GITHUB/$ACTIONS_RUNNER_FILE" .
+            cp "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" .
         else
             echo "Cache file checksum mismatch"
             download_and_verify
             # Save to cache for future use
-            mkdir -p "$CACHE_DIR_GITHUB"
-            cp "$ACTIONS_RUNNER_FILE" "$CACHE_DIR_GITHUB/"
+            mkdir -p "${CACHE_DIR_GITHUB}"
+            cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
         fi
     else
         echo "Runner package not found in cache"
         download_and_verify
         # Save to cache for future use
-        mkdir -p "$CACHE_DIR_GITHUB"
-        cp "$ACTIONS_RUNNER_FILE" "$CACHE_DIR_GITHUB/"
+        mkdir -p "${CACHE_DIR_GITHUB}"
+        cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
     fi
 else
     echo "Cache directory not available, downloading directly..."
     download_and_verify
 fi
 
-tar xzf "./$ACTIONS_RUNNER_FILE"
+tar xzf "./${ACTIONS_RUNNER_FILE}"
 
 echo "Configure runner"
 ./config.sh --unattended --replace --url https://github.com/${GITHUB_REPOSITORY} --token ${GITHUB_RUNNER_TOKEN} --name "$(hostname)-${SERVER_TYPE_NAME}-${SERVER_LOCATION_NAME}" --runnergroup "${GITHUB_RUNNER_GROUP}" --labels "${GITHUB_RUNNER_LABELS}" --work _work --ephemeral


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions Runner from version 2.306.0 (July 2023) to 2.330.0 (November 2025)
- Refactor startup scripts to make future version updates easier by using variables for version and architecture
- Add comment with link to releases page for quick reference when updating