### PR TITLE
Update requests-cache for requests 2.34 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         "PyGithub==2.8.1",
         "hcloud==2.3.0",
-        "requests-cache==1.2.1",
+        "requests-cache==1.3.2",
         "PyYAML==6.0.3",
         "prometheus_client==0.24.1",
         "streamlit==1.49.1",


### PR DESCRIPTION
Fixes #111.

Updates `requests-cache` from `1.2.1` to `1.3.2`. `requests-cache 1.3.2` includes the upstream compatibility fix for `requests>=2.34`, where `CachedResponse` deserialization could fail with:

```text
NameError: name 'RequestsCookieJar' is not defined
```

Validation performed:

```bash
python3 -m venv .venv
. .venv/bin/activate
pip install 'PyGithub==2.8.1' 'hcloud==2.3.0' 'requests-cache==1.3.2' 'PyYAML==6.0.3' 'prometheus_client==0.24.1' 'streamlit==1.49.1' 'psutil>=7.2.1'
python - <<'PY'
import importlib.metadata as m
from requests_cache.serializers import cattrs
print('requests', m.version('requests'))
print('requests-cache', m.version('requests-cache'))
print('cattrs serializer', cattrs.__name__)
PY
```

This resolved with:

```text
requests 2.34.2
requests-cache 1.3.2
cattrs serializer requests_cache.serializers.cattrs
```

Note: a direct `pip install .` from the repository is currently blocked by the existing release placeholder `version="__VERSION__"` in `setup.py`, so I validated the changed dependency set directly instead.
