### PR TITLE
Prune docker build cache in recycle.sh

### DIFF
--- a/testflows/github/hetzner/runners/scripts/recycle.sh
+++ b/testflows/github/hetzner/runners/scripts/recycle.sh
@@ -59,8 +59,12 @@ docker container prune -f || echo "warn: docker container prune failed" >&2
 # Prune all unused Docker volumes
 docker volume prune -f || echo "warn: docker volume prune failed" >&2
 
-# Prune all dangling Docker images
-# Intentionally keeping base images for reuse
+# Prune Docker build cache. This is reported separately by `docker system df`
+# and is not removed by image/container/volume prune commands.
+docker builder prune -af || echo "warn: docker builder prune failed" >&2
+
+# Prune all dangling Docker images.
+# Intentionally keeping tagged/base images for reuse.
 docker image prune -f || echo "warn: docker image prune failed" >&2
 
 # Remove any credentials written to the home directory


### PR DESCRIPTION
The existing recycle.sh script does not clean the docker build cache, which can slowly grow to hundreds of GB.

This PR adds `docker builder prune -af` to clean the build cache.