### PR TITLE
Fix crash from hcloud datacenter deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "PyGithub==2.8.1",
-        "hcloud==2.3.0",
+        "hcloud==2.22.0",
         "requests-cache==1.3.2",
         "PyYAML==6.0.3",
         "prometheus_client==0.24.1",

--- a/testflows/github/hetzner/runners/metrics.py
+++ b/testflows/github/hetzner/runners/metrics.py
@@ -1122,7 +1122,7 @@ def update_zombie_servers(zombie_servers_dict):
     for server_name, zombie_server in zombie_servers_dict.items():
         server = zombie_server.server
         server_type = server.server_type.name
-        location = server.datacenter.location.name
+        location = server.location.name
         key = (server_type, location)
 
         # Count by type and location
@@ -1238,7 +1238,7 @@ def update_recycled_servers(servers):
         # Check if this is a recycled server by name prefix
         if server.name.startswith(recycle_server_name_prefix):
             server_type = server.server_type.name
-            location = server.datacenter.location.name
+            location = server.location.name
             key = (server_type, location)
 
             # Count by type and location

--- a/testflows/github/hetzner/runners/scale_down.py
+++ b/testflows/github/hetzner/runners/scale_down.py
@@ -124,7 +124,7 @@ def delete_server(server: BoundServer, action: str = "delete"):
         error_details = {
             "error": str(e),
             "server_type": server.server_type.name,
-            "location": server.datacenter.location.name,
+            "location": server.location.name,
             "labels": ",".join(server_labels),
             "timestamp": time.time(),
         }
@@ -133,7 +133,7 @@ def delete_server(server: BoundServer, action: str = "delete"):
             error_type=f"{action}_failed",
             server_name=server.name,
             server_type=server.server_type.name,
-            server_location=server.datacenter.location.name,
+            server_location=server.location.name,
             error_details=error_details,
         )
 
@@ -207,7 +207,7 @@ def delete_recyclable_server(
 
         def sorting_key(server):
             server_type_name = server.server_type.name
-            server_location_name = server.datacenter.location.name
+            server_location_name = server.location.name
             server_age = age(server) if server else 0
             try:
                 return (60 - server_age.minutes) - server_prices[server_type_name][
@@ -629,7 +629,7 @@ def scale_down(
                                 ) as action:
                                     metrics.record_server_deletion(
                                         server_type=powered_off_server.server.server_type.name,
-                                        location=powered_off_server.server.datacenter.location.name,
+                                        location=powered_off_server.server.location.name,
                                         reason="powered_off",
                                     )
                                     delete_server(
@@ -676,7 +676,7 @@ def scale_down(
                                 ) as action:
                                     metrics.record_server_deletion(
                                         server_type=zombie_server.server.server_type.name,
-                                        location=zombie_server.server.datacenter.location.name,
+                                        location=zombie_server.server.location.name,
                                         reason="zombie",
                                     )
                                     delete_server(
@@ -735,7 +735,7 @@ def scale_down(
                                     ):
                                         metrics.record_server_deletion(
                                             server_type=runner_server.server_type.name,
-                                            location=runner_server.datacenter.location.name,
+                                            location=runner_server.location.name,
                                             reason="unused",
                                         )
                                         delete_server(

--- a/testflows/github/hetzner/runners/scale_up.py
+++ b/testflows/github/hetzner/runners/scale_up.py
@@ -256,7 +256,7 @@ def server_setup(
             f'SERVER_NAME="{server.name}" '
             f'SERVER_ID="{server.id}" '
             f'SERVER_TYPE_NAME="{server.server_type.name}" '
-            f'SERVER_LOCATION_NAME="{server.datacenter.location.name}" '
+            f'SERVER_LOCATION_NAME="{server.location.name}" '
             f"bash -s' < {startup_script}",
             stacklevel=5,
         )
@@ -1489,7 +1489,7 @@ def scale_up(
                                     ]
                                 ),
                                 server_type=server.server_type,
-                                server_location=server.datacenter.location,
+                                server_location=server.location,
                                 server_volumes=[
                                     Volume(
                                         name=get_volume_name(volume.name),

--- a/testflows/github/hetzner/runners/servers.py
+++ b/testflows/github/hetzner/runners/servers.py
@@ -170,7 +170,7 @@ def list(args, config: Config):
                 f"{server.id},",
                 f"{ip_address(server)},",
                 f"{server.server_type.name},",
-                f"{server.datacenter.location.name},",
+                f"{server.location.name},",
                 f"{server.image.name},",
                 f"{server.image.architecture},",
                 f"{server.image.os_flavor},",
@@ -279,7 +279,7 @@ def delete(args, config: Config):
 
     for server in delete_servers:
         with Action(
-            f"🗑️  Deleting server {server.name} with id {server.id} in {server.datacenter.location.name}"
+            f"🗑️  Deleting server {server.name} with id {server.id} in {server.location.name}"
         ):
             server.delete()
 


### PR DESCRIPTION
Hetzner Cloud is phasing out datacenters (see changelog 2025-12-16), so Server.datacenter now returns None and access raises AttributeError, breaking the scale-down cycle. Switch to the top-level Server.location property everywhere and bump hcloud to 2.22.0.