### PR TITLE
Fix #119 - dataclass mutable-default crash on Python 3.11+ with new hcloud

### DIFF
--- a/testflows/github/hetzner/runners/config/config.py
+++ b/testflows/github/hetzner/runners/config/config.py
@@ -100,8 +100,12 @@ class standby_runner:
 
 @dataclass
 class deploy_:
-    server_type: ServerType = server_type("cx23")
-    image: Image = image("x86:system:ubuntu-22.04")
+    server_type: ServerType = dataclasses.field(
+        default_factory=lambda: server_type("cx23")
+    )
+    image: Image = dataclasses.field(
+        default_factory=lambda: image("x86:system:ubuntu-22.04")
+    )
     location: Location = None
     setup_script: str = os.path.join(current_dir, "..", "scripts", "deploy", "setup.sh")
 
@@ -133,10 +137,16 @@ class Config:
     max_runners: int = 10
     max_runners_for_label: list[tuple[set[str], int]] = None
     max_runners_in_workflow_run: int = None
-    default_image: Image = image("x86:system:ubuntu-22.04")
-    default_server_type: ServerType = server_type("cx23")
+    default_image: Image = dataclasses.field(
+        default_factory=lambda: image("x86:system:ubuntu-22.04")
+    )
+    default_server_type: ServerType = dataclasses.field(
+        default_factory=lambda: server_type("cx23")
+    )
     default_location: Location = None
-    default_volume_location: Location = location("nbg1")
+    default_volume_location: Location = dataclasses.field(
+        default_factory=lambda: location("nbg1")
+    )
     default_volume_size: int = 10
     workers: int = 10
     scripts: str = os.path.join(current_dir, "..", "scripts")


### PR DESCRIPTION
New hcloud makes ServerType/Image/Location unhashable (they define __eq__ without __hash__). On Python 3.11+, @dataclass rejects any unhashable default, so class-level defaults like server_type("cx23") raise ValueError at import time. Use default_factory instead.
Fixes #119 